### PR TITLE
Fix parse error for "user" field from API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ pub struct Usage {
     #[serde(default, deserialize_with = "examples_vector", alias = "example")]
     pub examples: Vec<Example>,
     #[serde(alias = "url")]
-    pub user: Url,
+    pub user: String,
     pub label: Option<String>,
     #[serde(rename = "type")]
     pub ty: Option<UsageType>,


### PR DESCRIPTION
Fixes this error in the tests:
  thread 'json' (2221064) panicked at tests/lib.rs:26:73:
  called `Result::unwrap()` on an `Err` value: Error("relative URL without a base: \"(multiple)\"", line: 1623, column: 40)

due to the "user" field not always containing a valid URL.

I noticed this while running the tests for `fastobo`